### PR TITLE
fix: regular admins can use MA.ServerCommands and call any console command

### DIFF
--- a/lua/metrostroi_advanced/sv_metrostroi_advanced.lua
+++ b/lua/metrostroi_advanced/sv_metrostroi_advanced.lua
@@ -122,7 +122,7 @@ timer.Simple(1.5,function()
 end)
 
 net.Receive("MA.ServerCommands",function(ln,ply)
-	if (not ply:IsAdmin()) then return end
+	if (not ply:IsSuperAdmin()) then return end
 	local com = net.ReadString()
 	local val = net.ReadString()
 	if (com == "ma_voltage") then com = "metrostroi_voltage" end


### PR DESCRIPTION
restrict random admins access to RunConsoleCommand